### PR TITLE
Destroy login activity after logging in

### DIFF
--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/LoginActivity.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/LoginActivity.java
@@ -74,7 +74,6 @@ public class LoginActivity extends AppCompatActivity {
                              * Get User object from Firestore
                              */
                             Session session = Session.getInstance(email,getApplicationContext());
-                            User user = session.getUser();
 
                         }else{
                             Toast.makeText(com.CMPUT301F21T30.Habiteer.LoginActivity.this, "Error! "+task.getException().getMessage(), Toast.LENGTH_SHORT).show();
@@ -94,6 +93,7 @@ public class LoginActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 startActivity(new Intent(getApplicationContext(), SignupActivity.class)); //move to the signup activity
+                finish(); // close the current activity, so user can't go back
             }
         });
 

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/Session.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/Session.java
@@ -7,6 +7,8 @@ import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
 import com.CMPUT301F21T30.Habiteer.ui.habit.Habit;
+
+import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
@@ -47,8 +49,9 @@ public class Session {
                 System.out.println("Session user: " + user.getEmail() + ", " + user.getHabitList()); // TODO
                 Toast.makeText(context, "You have been logged in", Toast.LENGTH_SHORT).show();
                 Intent intent = new Intent(context, MainActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_NEW_TASK); // remove login activity and start main activity
                 context.startActivity(intent); // if logged in, go to the main activity
+
             }
         });
     }

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/SignupActivity.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/SignupActivity.java
@@ -138,6 +138,7 @@ public class SignupActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 startActivity(new Intent(getApplicationContext(), LoginActivity.class)); //goes to the login activity
+                finish(); // close the current activity, so user can't go back
             }
         });
     }


### PR DESCRIPTION
Makes sure the user cannot return (via the back button) to the login screen after they have logged in, or when switching between the signup and login screens.