### PR TITLE
#69 change to hashmap

### DIFF
--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/Session.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/Session.java
@@ -53,7 +53,7 @@ public class Session {
                 user = documentSnapshot.toObject(User.class);
                 user.setEmail(usersDocRef.getId()); // document does not set email to User, so we set manually
 
-                // Get habits that belong to User from Firestore and append to habitList
+                // Get habits that belong to User from Firestore and append to habitHashMap
                 if (user.getHabitIdList().size() != 0) {
                     for (int i = 0; i < user.getHabitIdList().size(); i++) {
                         DocumentReference habitsDocRef = db.collection("Habits").document(user.getHabitIdList().get(i));
@@ -172,9 +172,10 @@ public class Session {
      * @param habit a Habit object.
      */
     public void deleteHabit(Habit habit) {
-        /* Delete habit in in-app list */
-        habitHashMap.remove(habit);
         String habitID = habit.getId();
+        /* Delete habit in in-app list/hashmap */
+        habitHashMap.remove(habitID);
+
         ArrayList<String> habitIdList = user.getHabitIdList();
         habitIdList.remove(habitID);
         user.setHabitIdList(habitIdList);

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/EditHabitFragment.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/EditHabitFragment.java
@@ -43,7 +43,7 @@ import ca.antonious.materialdaypicker.MaterialDayPicker;
 public class EditHabitFragment extends Fragment {
 
     private com.CMPUT301F21T30.Habiteer.ui.addEditHabit.AddEditHabitModel mViewModel;
-
+    private String habitID;
     public static EditHabitFragment newInstance() {
         return new EditHabitFragment();
     }
@@ -56,8 +56,9 @@ public class EditHabitFragment extends Fragment {
         mViewModel = new ViewModelProvider(this).get(com.CMPUT301F21T30.Habiteer.ui.addEditHabit.AddEditHabitModel.class);
 
         // get the selected habit
-        int habitIndex = requireActivity().getIntent().getExtras().getInt("habitIndex");
-        Habit selectedHabit = Session.getInstance().getHabitList().get(habitIndex);
+        habitID = requireActivity().getIntent().getExtras().getString("habitID");
+
+        Habit selectedHabit = Session.getInstance().getHabitHashMap().get(habitID);
 
         TextInputLayout habitDateInput = view.findViewById(R.id.textInput_habitEndDate);
 
@@ -147,8 +148,7 @@ public class EditHabitFragment extends Fragment {
                 List<MaterialDayPicker.Weekday> weekdayList = dayPicker.getSelectedDays();
 
                 // get selected habit from User
-                int habitIndex = requireActivity().getIntent().getExtras().getInt("habitIndex");
-                Habit currentHabit  = Session.getInstance().getHabitList().get(habitIndex);
+                Habit currentHabit  = Session.getInstance().getHabitHashMap().get(habitID);
 
                 // Set the date only if it was changed
                 if (mViewModel.getEndDate() != null) {
@@ -168,7 +168,7 @@ public class EditHabitFragment extends Fragment {
 
                 // update and navigate back to view habit
                 Intent intent = new Intent(getContext(), ViewHabitActivity.class);
-                intent.putExtra("habitIndex",habitIndex); // include the index of the habit
+                intent.putExtra("habitID",habitID); // include the index of the habit
                 intent.addFlags(FLAG_ACTIVITY_CLEAR_TOP); // update the existing view habit activity instead of making a new one
                 startActivity(intent);
 //

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ListHabitFragment.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ListHabitFragment.java
@@ -25,13 +25,14 @@ import com.CMPUT301F21T30.Habiteer.ui.addEditHabit.AddEditHabitActivity;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class ListHabitFragment extends Fragment {
 
     private ListHabitViewModel listHabitViewModel;
     private FragmentListhabitBinding binding;
-    private ArrayList<Habit> habitList;
+//    private ArrayList<Habit> habitList;
     private HabitAdapter habitAdapter;
     private RecyclerView habitRecycler;
 
@@ -40,11 +41,11 @@ public class ListHabitFragment extends Fragment {
         binding = FragmentListhabitBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
         listHabitViewModel = new ViewModelProvider(this).get(ListHabitViewModel.class);
-        habitList = new ArrayList<>();
+//        habitList = new ArrayList<>();
         habitRecycler = root.findViewById(R.id.habit_recycler);
-        listHabitViewModel.getHabits().observe(getViewLifecycleOwner(), new Observer<List<Habit>>() {
+        listHabitViewModel.getHabits().observe(getViewLifecycleOwner(), new Observer<HashMap<String,Habit>>() {
             @Override
-            public void onChanged(@Nullable List<Habit> habits) {
+            public void onChanged(@Nullable HashMap<String,Habit> habits) {
                 habitAdapter.notifyDataSetChanged();
                 Session session = Session.getInstance();
                 System.out.println("ListHabitFragment Session: " + session);

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ListHabitViewModel.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ListHabitViewModel.java
@@ -14,8 +14,7 @@ import androidx.lifecycle.ViewModel;
 
 import com.CMPUT301F21T30.Habiteer.Session;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 
 /**
  * This class handles data sent to the HabitAdapter
@@ -23,15 +22,15 @@ import java.util.List;
 public class ListHabitViewModel extends ViewModel {
 
     /* Habit list data */
-    private MutableLiveData<List<Habit>> mHabits = new MutableLiveData<>();
-    private ArrayList<Habit> habitList;
+    private MutableLiveData<HashMap<String,Habit>> mHabits = new MutableLiveData<>();
+    private HashMap<String,Habit> habitList;
 
     /* Tab data */
     private MutableLiveData<Integer> mIndex = new MutableLiveData<>();
 
 
-    public LiveData<List<Habit>> getHabits() {
-        habitList = Session.getInstance().getHabitList();
+    public LiveData<HashMap<String,Habit>> getHabits() {
+        habitList = Session.getInstance().getHabitHashMap();
         mHabits.setValue(habitList);
         return mHabits;
     }

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ViewHabitActivity.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ViewHabitActivity.java
@@ -32,7 +32,7 @@ public class ViewHabitActivity extends AppCompatActivity {
     Calendar calendar;
     String todayDate;
     SimpleDateFormat dateFormat;
-    int habitIndex;
+    String habitID;
 
 
     @Override
@@ -57,12 +57,12 @@ public class ViewHabitActivity extends AppCompatActivity {
 
         // get the habit index from the intent
         Bundle bundle = getIntent().getExtras();
-        habitIndex = bundle.getInt("habitIndex");
+        habitID = bundle.getString("habitID");
 
 
 
         // get current habit at that index
-        Habit currentHabit = Session.getInstance().getHabitList().get(habitIndex);
+        Habit currentHabit = Session.getInstance().getHabitHashMap().get(habitID);
 
         // get habit info
         String habitname = currentHabit.getHabitName();
@@ -108,7 +108,7 @@ public class ViewHabitActivity extends AppCompatActivity {
                 todayDate = dateFormat.format(calendar.getTime());
 
                 Intent intent = new Intent(ViewHabitActivity.this, AddHabitEventActivity.class);
-                intent.putExtra("habitIndex", String.valueOf(habitIndex));
+                intent.putExtra("habitIndex", String.valueOf(habitID));
                 intent.putExtra("eventDate", todayDate);
                 startActivity(intent);
 //                startActivity(new Intent(getApplicationContext(), AddHabitEvent.class)); //the user goes to the addHabitEvent activity
@@ -135,7 +135,7 @@ public class ViewHabitActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 Intent intent = new Intent(getApplicationContext(), AddEditHabitActivity.class);
-                intent.putExtra("habitIndex",habitIndex); // include the index of the habit
+                intent.putExtra("habitID",habitID); // include the index of the habit
                 intent.putExtra("EditMode",true); // let the activity know to use the edit fragment
                 startActivity(intent); //the user goes to the EditHabit activity
             }

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ViewHabitActivity.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ViewHabitActivity.java
@@ -108,7 +108,7 @@ public class ViewHabitActivity extends AppCompatActivity {
                 todayDate = dateFormat.format(calendar.getTime());
 
                 Intent intent = new Intent(ViewHabitActivity.this, AddHabitEventActivity.class);
-                intent.putExtra("habitIndex", String.valueOf(habitID));
+                intent.putExtra("habitID", String.valueOf(habitID));
                 intent.putExtra("eventDate", todayDate);
                 startActivity(intent);
 //                startActivity(new Intent(getApplicationContext(), AddHabitEvent.class)); //the user goes to the addHabitEvent activity

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ViewHabitActivity.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habit/ViewHabitActivity.java
@@ -61,7 +61,7 @@ public class ViewHabitActivity extends AppCompatActivity {
 
 
 
-        // get current habit at that index
+        // get current habit with id
         Habit currentHabit = Session.getInstance().getHabitHashMap().get(habitID);
 
         // get habit info
@@ -124,6 +124,7 @@ public class ViewHabitActivity extends AppCompatActivity {
             public void onClick(View view) {
                 //startActivity(new Intent(getApplicationContext(), DeleteHabit.class)); //the user goes to the DeleteHabit activity
                 Session.getInstance().deleteHabit(currentHabit);
+
                 finish();
             }
         });

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habitEvents/AddHabitEventActivity.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/habitEvents/AddHabitEventActivity.java
@@ -20,8 +20,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 public class AddHabitEventActivity extends AppCompatActivity {
     // To initialize variables
     String date = "";
-    int habitIndex;
-    String indexString;
+    String habitID;
     TextView eventDateView;
     TextInputEditText eventNameInput;
     String eventName;
@@ -42,8 +41,7 @@ public class AddHabitEventActivity extends AppCompatActivity {
         setContentView(R.layout.add_habit_event_activity);
 
         // To pass habit index
-        indexString = getIntent().getStringExtra("habitIndex");
-        habitIndex = Integer.parseInt(indexString);
+        habitID = getIntent().getStringExtra("habitID");
 
         // date of event
         date = getIntent().getStringExtra("eventDate");
@@ -53,7 +51,7 @@ public class AddHabitEventActivity extends AppCompatActivity {
         eventDateView.setText("Event date: " + date);
 
         // This toast confirms correct date is being passed
-        Toast.makeText(AddHabitEventActivity.this, "Date passed: " + date + ", Habit index: " + habitIndex, Toast.LENGTH_SHORT).show();
+        Toast.makeText(AddHabitEventActivity.this, "Date passed: " + date + ", Habit id: " + habitID, Toast.LENGTH_SHORT).show();
 
         // To connect to the add button and set an on click listener
         addButton = findViewById(R.id.button_addHabitEvent);


### PR DESCRIPTION
Closes #32.
Changed the habit list in session into a hashmap, where the habit ID is the key. For the habit list adapter, I converted the hashmap to a list where required, but the view and edit habit functions have all been changed to use habit ID as the key. 

Works as of 4696eaa (the main branch as of posting), the still needs to be tested with #60 before #69 can be closed, which will deal with habit sorting and the today list.

