### PR TITLE
add/edit habit data validation, updates to intent tests

### DIFF
--- a/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/AddHabitTests.java
+++ b/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/AddHabitTests.java
@@ -59,6 +59,16 @@ public class AddHabitTests {
         assertEquals(addedit.getSupportFragmentManager().findFragmentById(R.id.container).getClass(), AddHabitFragment.class);
     }
 
+    /**
+     * Test if input validation prevents the activity from submitting empty fields
+     */
+    @Test
+    public void testInputValidation() {
+        solo.clickOnView(solo.getView(R.id.FAB_addHabit));
+        solo.assertCurrentActivity("Wrong Activity", AddEditHabitActivity.class);
+        solo.clickOnText("Save"); // click on the save button without entering anything
+        solo.assertCurrentActivity("Wrong Activity!",AddEditHabitActivity.class); // activity should not change, since no empty fields allowed
+    }
     @Test
     public void TestAddHabitDatePicker() {
         solo.clickOnView(solo.getView(R.id.FAB_addHabit));

--- a/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/AddHabitTests.java
+++ b/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/AddHabitTests.java
@@ -16,10 +16,13 @@ import com.CMPUT301F21T30.Habiteer.ui.addEditHabit.AddHabitFragment;
 import com.google.android.material.textfield.TextInputLayout;
 import com.robotium.solo.Solo;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import ca.antonious.materialdaypicker.MaterialDayPicker;
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -66,9 +69,28 @@ public class AddHabitTests {
     public void testInputValidation() {
         solo.clickOnView(solo.getView(R.id.FAB_addHabit));
         solo.assertCurrentActivity("Wrong Activity", AddEditHabitActivity.class);
-        solo.clickOnText("Save"); // click on the save button without entering anything
-        solo.assertCurrentActivity("Wrong Activity!",AddEditHabitActivity.class); // activity should not change, since no empty fields allowed
+        sharedActions.saveAndCheckActivityChange(solo); // test with all fields empty
+        TextInputLayout nameField = (TextInputLayout) solo.getView(R.id.textInput_habitName);
+        TextInputLayout reasonField = (TextInputLayout) solo.getView(R.id.textInput_habitReason);
+        // test with name field entered
+        solo.enterText(nameField.getEditText(),"Run");
+        sharedActions.saveAndCheckActivityChange(solo);
+        // test with name and reason entered
+        solo.enterText(reasonField.getEditText(),"Get fit");
+        sharedActions.saveAndCheckActivityChange(solo);
+        // test with name,reason,date entered (days of week not selected)
+        solo.clickOnView(solo.getView(R.id.textInput_habitStartDate));
+        solo.clickOnButton(1);
+        solo.clickOnButton(2);
+        sharedActions.saveAndCheckActivityChange(solo);
+        // test with everything entered
+        MaterialDayPicker dayPicker = (MaterialDayPicker) solo.getView(R.id.AddEdit_day_picker);
+        solo.clickOnView(dayPicker.getChildAt(0)); // click on a day
+        solo.clickOnText("Save");
+        solo.assertCurrentActivity("Habit not saved", MainActivity.class); // habit should have saved
+
     }
+
     @Test
     public void TestAddHabitDatePicker() {
         solo.clickOnView(solo.getView(R.id.FAB_addHabit));
@@ -103,5 +125,9 @@ public class AddHabitTests {
             assertTrue(solo.waitForText("Run",1,2000));
 
     }
-    // TODO: teardown using delete
+    // teardown using delete
+    @After
+    public void teardown() {
+        sharedActions.deleteHabit(solo);
+    }
 }

--- a/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/EditHabitTest.java
+++ b/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/EditHabitTest.java
@@ -23,6 +23,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import ca.antonious.materialdaypicker.MaterialDayPicker;
+
 /**
  * Instrumented test, which will execute on an Android device.
  *
@@ -57,6 +59,45 @@ public class EditHabitTest {
         // see if the right fragment appears
         AddEditHabitActivity addedit = (AddEditHabitActivity)  solo.getCurrentActivity();
         assertEquals(addedit.getSupportFragmentManager().findFragmentById(R.id.container).getClass(), EditHabitFragment.class);
+    }
+    /**
+     * Test if input validation prevents the activity from submitting empty fields
+     */
+    @Test
+    public void testInputValidation() {
+        solo.clickOnView(solo.getView(R.id.habit_recycler));
+        solo.clickOnView(solo.getView(R.id.edit));
+
+        solo.assertCurrentActivity("Wrong Activity!",AddEditHabitActivity.class); // activity should not change, since no empty fields allowed
+
+        TextInputLayout nameField = (TextInputLayout) solo.getView(R.id.textInput_habitName);
+        clearFieldAndTest(nameField);
+
+        TextInputLayout reasonField = (TextInputLayout) solo.getView(R.id.textInput_habitReason);
+        clearFieldAndTest(reasonField);
+
+        TextInputLayout dateField = (TextInputLayout) solo.getView(R.id.textInput_habitEndDate);
+        clearFieldAndTest(dateField);
+
+        // remove day selection and check if that is allowed
+        MaterialDayPicker dayPicker = (MaterialDayPicker) solo.getView(R.id.AddEdit_day_picker);
+        dayPicker.clearSelection();
+        sharedActions.saveAndCheckActivityChange(solo);
+        solo.clickOnView(dayPicker.getChildAt(0)); // click on a day
+        solo.clickOnText("Save");
+        solo.assertCurrentActivity("Habit not saved", ViewHabitActivity.class); // habit should have saved if everything is filled in !
+    }
+
+    /**
+     * Clears a field and attempts to save the habit to test input validation.
+     * Adds text back afterwards, so each text field can be tested individually..
+     * @param textBox a text box to test
+     */
+    private void clearFieldAndTest(TextInputLayout textBox) {
+        solo.clearEditText(textBox.getEditText()); // clear the name field
+        sharedActions.saveAndCheckActivityChange(solo);
+        solo.enterText(textBox.getEditText(),"Test"); // add something back
+
     }
     @Test
     public void testEditView() {

--- a/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/sharedActions.java
+++ b/app/src/androidTest/java/com/CMPUT301F21T30/Habiteer/sharedActions.java
@@ -4,8 +4,11 @@ import android.widget.EditText;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import com.CMPUT301F21T30.Habiteer.ui.addEditHabit.AddEditHabitActivity;
 import com.google.android.material.textfield.TextInputLayout;
 import com.robotium.solo.Solo;
+
+import ca.antonious.materialdaypicker.MaterialDayPicker;
 
 public class sharedActions {
     /**
@@ -32,6 +35,9 @@ public class sharedActions {
         TextInputLayout reasonField = (TextInputLayout) solo.getView(R.id.textInput_habitReason);
         solo.enterText(nameField.getEditText(),"Run");
         solo.enterText(reasonField.getEditText(),"Get fit");
+        // fill in day of week
+        MaterialDayPicker dayPicker = (MaterialDayPicker) solo.getView(R.id.AddEdit_day_picker);
+        solo.clickOnView(dayPicker.getChildAt(0)); // click on a day
         //save
         solo.clickOnText("Save");
     }
@@ -39,5 +45,15 @@ public class sharedActions {
         solo.clickOnView(solo.getView(R.id.habit_recycler));
         solo.clickOnView(solo.getView(R.id.delete));
         solo.assertCurrentActivity("Wrong Activity", MainActivity.class);
+    }
+
+    /**
+     * Clicks "save", and make sure the current activity does not change.
+     * Used for testing input validation in Add and Edit habit screens
+     * @param solo
+     */
+    public static void saveAndCheckActivityChange(Solo solo) {
+        solo.clickOnText("Save"); // click on the save button without entering anything
+        solo.assertCurrentActivity("Wrong Activity!", AddEditHabitActivity.class); // activity should not change, since no empty fields allowed
     }
 }

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/AddHabitFragment.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/AddHabitFragment.java
@@ -9,11 +9,13 @@ import androidx.fragment.app.Fragment;
 import androidx.core.util.Pair;
 import androidx.lifecycle.ViewModelProvider;
 
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.TextView;
 
 
 import com.CMPUT301F21T30.Habiteer.R;
@@ -28,6 +30,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.TimeZone;
 
 import ca.antonious.materialdaypicker.MaterialDayPicker;
@@ -38,7 +41,7 @@ import ca.antonious.materialdaypicker.MaterialDayPicker;
  *  See Github #44, date picker can sometimes be one day off due to timezone issues
  *  TODO: Days of the week picker yet to be implemented
  */
-public class AddHabitFragment extends Fragment  {
+public class AddHabitFragment extends BaseAddEditFragment  {
 
     private AddEditHabitModel mViewModel;
 
@@ -106,44 +109,51 @@ public class AddHabitFragment extends Fragment  {
         return view;
 
     }
-    private void handleDaysOfWeek(View view) {
 
 
-    }
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         // get the text fields
         TextInputLayout nameBox = getView().findViewById(R.id.textInput_habitName);
         TextInputLayout reasonBox = getView().findViewById(R.id.textInput_habitReason);
+        TextInputLayout dateBox = getView().findViewById(R.id.textInput_habitStartDate);
         MaterialDayPicker dayPicker = getView().findViewById(R.id.AddEdit_day_picker);
+        TextInputLayout[] boxes = {nameBox,reasonBox,dateBox};
 
 
         switch (item.getItemId()) {
 
             case R.id.button_addHabit: // when the save button is pressed
-                // create the new habit
+                // Only submit info if there are no empty fields
+                if (!hasEmptyFields(boxes,dayPicker)) {
+                    // create the new habit
+                    // get input from text fields
+                    String habitName = nameBox.getEditText().getText().toString();
+                    String reason = reasonBox.getEditText().getText().toString();
 
-                // get input from text fields
-                String habitName = nameBox.getEditText().getText().toString();
-                String reason = reasonBox.getEditText().getText().toString();
 
-                // apply length limit to strings
-                habitName = habitName.substring(0,Math.min(habitName.length(),nameBox.getCounterMaxLength()));  // either the max length or string length, which one is smaller
-                reason = reason.substring(0,Math.min(reason.length(),reasonBox.getCounterMaxLength())); // either the max length or string length, which one is smaller
+                    // apply length limit to strings
+                    habitName = habitName.substring(0, Math.min(habitName.length(), nameBox.getCounterMaxLength()));  // either the max length or string length, which one is smaller
+                    reason = reason.substring(0, Math.min(reason.length(), reasonBox.getCounterMaxLength())); // either the max length or string length, which one is smaller
 
-                // get dates from viewmodel
-                Date startDate = mViewModel.getStartDate();
-                Date endDate = mViewModel.getEndDate();
-                // get selected days of week
-                List<MaterialDayPicker.Weekday> weekdayList = dayPicker.getSelectedDays();
-                // make a new habit
-                Habit newHabit = new Habit(habitName,startDate,endDate,weekdayList,reason);
-                // store the new habit
-                Session session = Session.getInstance();
-                session.addHabit(newHabit);
-                // close the activity
-                getActivity().finish();
-                return true;
+                    // get dates from viewmodel
+                    Date startDate = mViewModel.getStartDate();
+                    Date endDate = mViewModel.getEndDate();
+                    // get selected days of week
+                    List<MaterialDayPicker.Weekday> weekdayList = dayPicker.getSelectedDays();
+                    // make a new habit
+                    Habit newHabit = new Habit(habitName, startDate, endDate, weekdayList, reason);
+                    // store the new habit
+                    Session session = Session.getInstance();
+                    session.addHabit(newHabit);
+                    // close the activity
+                    getActivity().finish();
+                    return true;
+                }
+                else {
+                    return false;
+                }
+
         }
         return false;
     }

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/BaseAddEditFragment.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/BaseAddEditFragment.java
@@ -1,0 +1,44 @@
+package com.CMPUT301F21T30.Habiteer.ui.addEditHabit;
+
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import com.CMPUT301F21T30.Habiteer.R;
+import com.google.android.material.textfield.TextInputLayout;
+
+import java.util.Objects;
+
+import ca.antonious.materialdaypicker.MaterialDayPicker;
+
+
+public class BaseAddEditFragment extends Fragment {
+    public boolean hasEmptyFields(TextInputLayout[] boxes, MaterialDayPicker dayPicker) {
+        boolean emptyFields = false;
+        TextView errorText = getView().findViewById(R.id.dayPicker_ErrorText);
+
+        for (TextInputLayout box:boxes) {
+            String boxContents = Objects.requireNonNull(box.getEditText()).getText().toString();
+            if (TextUtils.isEmpty(boxContents)) {
+                // if empty, show error message
+                box.setError(Objects.requireNonNull(box.getHint()).toString() + " field cannot be empty.");
+                box.setErrorEnabled(true);
+                emptyFields = true;
+
+            }
+            else {
+                // remove error messages
+                box.setErrorEnabled(false);
+            }
+        }
+        if (dayPicker.getSelectedDays().isEmpty()) {
+            errorText.setVisibility(View.VISIBLE); // show error message on day picker
+        }
+        else {
+            errorText.setVisibility(View.GONE); // remove error message on day picker
+        }
+        return emptyFields;
+    }
+}

--- a/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/EditHabitFragment.java
+++ b/app/src/main/java/com/CMPUT301F21T30/Habiteer/ui/addEditHabit/EditHabitFragment.java
@@ -40,7 +40,7 @@ import ca.antonious.materialdaypicker.MaterialDayPicker;
  *  See Github #44, date picker can sometimes be one day off due to timezone issues
  *  TODO: Days of the week picker yet to be implemented
  */
-public class EditHabitFragment extends Fragment {
+public class EditHabitFragment extends BaseAddEditFragment {
 
     private com.CMPUT301F21T30.Habiteer.ui.addEditHabit.AddEditHabitModel mViewModel;
     private String habitID;
@@ -136,44 +136,52 @@ public class EditHabitFragment extends Fragment {
     public boolean onOptionsItemSelected(MenuItem item) {
         TextInputLayout nameBox = requireView().findViewById(R.id.textInput_habitName);
         TextInputLayout reasonBox = requireView().findViewById(R.id.textInput_habitReason);
+        TextInputLayout dateBox = getView().findViewById(R.id.textInput_habitEndDate);
         MaterialDayPicker dayPicker = getView().findViewById(R.id.AddEdit_day_picker);
+        TextInputLayout[] boxes = {nameBox,reasonBox,dateBox}; // array of all text boxes
 
 
         switch (item.getItemId()) {
 
             case R.id.button_addHabit:
                 // edit the habit
-                String habitName = nameBox.getEditText().getText().toString();
-                String reason = reasonBox.getEditText().getText().toString();
-                List<MaterialDayPicker.Weekday> weekdayList = dayPicker.getSelectedDays();
+                // Only submit info if there are no empty fields
+                if (!hasEmptyFields(boxes,dayPicker)) {
+                    String habitName = nameBox.getEditText().getText().toString();
+                    String reason = reasonBox.getEditText().getText().toString();
+                    List<MaterialDayPicker.Weekday> weekdayList = dayPicker.getSelectedDays();
 
-                // get selected habit from User
-                Habit currentHabit  = Session.getInstance().getHabitHashMap().get(habitID);
+                    // get selected habit from User
+                    Habit currentHabit = Session.getInstance().getHabitHashMap().get(habitID);
 
-                // Set the date only if it was changed
-                if (mViewModel.getEndDate() != null) {
-                    Date endDate = mViewModel.getEndDate();
-                    currentHabit.setEndDate(endDate);
-                }
-                // set other data, with length limit
-                currentHabit.setHabitName(habitName.substring(0,Math.min(habitName.length(),nameBox.getCounterMaxLength())));  // either the max length or string length, which one is smaller
-                currentHabit.setReason(reason.substring(0,Math.min(reason.length(),reasonBox.getCounterMaxLength()))); // either the max length or string length, which one is smaller
-                currentHabit.setWeekdayList(weekdayList);
+                    // Set the date only if it was changed
+                    if (mViewModel.getEndDate() != null) {
+                        Date endDate = mViewModel.getEndDate();
+                        currentHabit.setEndDate(endDate);
+                    }
+                    // set other data, with length limit
+                    currentHabit.setHabitName(habitName.substring(0, Math.min(habitName.length(), nameBox.getCounterMaxLength())));  // either the max length or string length, which one is smaller
+                    currentHabit.setReason(reason.substring(0, Math.min(reason.length(), reasonBox.getCounterMaxLength()))); // either the max length or string length, which one is smaller
+                    currentHabit.setWeekdayList(weekdayList);
 
 
-                // call Session to update data on Firestore
-                Session.getInstance().updateHabit(currentHabit);
+                    // call Session to update data on Firestore
+                    Session.getInstance().updateHabit(currentHabit);
 
-                requireActivity().finish(); // close the activity
+                    requireActivity().finish(); // close the activity
 
-                // update and navigate back to view habit
-                Intent intent = new Intent(getContext(), ViewHabitActivity.class);
-                intent.putExtra("habitID",habitID); // include the index of the habit
-                intent.addFlags(FLAG_ACTIVITY_CLEAR_TOP); // update the existing view habit activity instead of making a new one
-                startActivity(intent);
+                    // update and navigate back to view habit
+                    Intent intent = new Intent(getContext(), ViewHabitActivity.class);
+                    intent.putExtra("habitID", habitID); // include the index of the habit
+                    intent.addFlags(FLAG_ACTIVITY_CLEAR_TOP); // update the existing view habit activity instead of making a new one
+                    startActivity(intent);
 //
 
-                return true;
+                    return true;
+                }
+                else {
+                    return false;
+                }
         }
         return false;
     }

--- a/app/src/main/res/layout/fragment_add_habit.xml
+++ b/app/src/main/res/layout/fragment_add_habit.xml
@@ -60,25 +60,7 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/textView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/hint_DayOfTheWeek" />
-
-            <ca.antonious.materialdaypicker.MaterialDayPicker
-                android:id="@+id/AddEdit_day_picker"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
+        <include layout="@layout/view_daypicker" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInput_habitReason"

--- a/app/src/main/res/layout/fragment_edit_habit.xml
+++ b/app/src/main/res/layout/fragment_edit_habit.xml
@@ -60,25 +60,7 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/textView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/hint_DayOfTheWeek" />
-
-            <ca.antonious.materialdaypicker.MaterialDayPicker
-                android:id="@+id/AddEdit_day_picker"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
+        <include layout="@layout/view_daypicker" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInput_habitReason"

--- a/app/src/main/res/layout/view_daypicker.xml
+++ b/app/src/main/res/layout/view_daypicker.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/AddEdit_day_picker_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="16dp"
+    android:layout_marginTop="16dp"
+    android:layout_marginEnd="16dp"
+    android:orientation="vertical"
+    tools:showIn="@layout/fragment_edit_habit">
+
+<TextView
+    android:id="@+id/DayPicker_title"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/hint_DayOfTheWeek" />
+
+<ca.antonious.materialdaypicker.MaterialDayPicker
+    android:id="@+id/AddEdit_day_picker"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+</ca.antonious.materialdaypicker.MaterialDayPicker>
+
+<TextView
+    android:id="@+id/dayPicker_ErrorText"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="8dp"
+    android:paddingTop="10dp"
+    android:text="@string/error_DayPicker"
+    android:textColor="@color/design_default_color_error"
+    android:textSize="12sp"
+    android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="title_addHabit">Add habit</string>
     <string name="title_editHabit">Add habit</string>
     <string name="add">Add</string>
+    <string name="error_DayPicker">Please select a day.</string>
 </resources>


### PR DESCRIPTION
* Closes #48.

 Data validation for Add and edit habit, ensures that an activity cannot be added or edited if any of the fields are empty.
 Also wrote some tests for these features, and updated the testing methods to also add the day of the week when creating a new habit.